### PR TITLE
feat: don't show StatusPage description when portal is used

### DIFF
--- a/src/modules/functions/file_set.cr
+++ b/src/modules/functions/file_set.cr
@@ -26,8 +26,9 @@ module Collision
   end
 
   def real_path(filepath : Path) : String | Nil
-    parts = filepath.parts
-    return nil if (parts - ["run", "user", "doc"]).size == parts.size - 3
+    {% if !env("FLATPAK_ID").nil? || file_exists?("/.flatpak-info") %}
+      return nil if filepath.parents.includes?(Path["/", "run", "user"])
+    {% end %}
     filepath.dirname.to_s
   end
 

--- a/src/modules/functions/file_set.cr
+++ b/src/modules/functions/file_set.cr
@@ -25,9 +25,15 @@ module Collision
     WINDOW_BOX.append(FILE_SET_SPINNER)
   end
 
+  def real_path(filepath : Path) : String | Nil
+    parts = filepath.parts
+    return nil if (parts - ["run", "user", "doc"]).size == parts.size - 3
+    filepath.dirname.to_s
+  end
+
   def set_file(filepath : Path)
     FILE_INFO.title = filepath.basename.to_s
-    FILE_INFO.description = filepath.dirname.to_s
+    FILE_INFO.description = real_path(filepath)
 
     FILE_SET_SPINNER.vexpand = true
     FILE_SET_SPINNER.visible = false


### PR DESCRIPTION
Not sure if there's a better/more reliable (or even faster) way to check, but for now checks if the path parents include `run` & `user` (only for flatpak, check is being done with macros)

closes: #57 