### PR TITLE
feat: gschema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,18 @@ desktop:
 
 install: mo
 	install -D -m 0755 bin/collision $(PREFIX)/bin/collision
+	install -D -m 0644 data/dev.geopjr.Collision.gschema.xml $(PREFIX)/share/glib-2.0/schemas/dev.geopjr.Collision.gschema.xml
 	install -D -m 0644 data/dev.geopjr.Collision.desktop $(PREFIX)/share/applications/dev.geopjr.Collision.desktop
 	install -D -m 0644 data/icons/dev.geopjr.Collision.svg $(PREFIX)/share/icons/hicolor/scalable/apps/dev.geopjr.Collision.svg
 	install -D -m 0644 data/icons/dev.geopjr.Collision-symbolic.svg $(PREFIX)/share/icons/hicolor/symbolic/apps/dev.geopjr.Collision-symbolic.svg
-	gtk-update-icon-cache /usr/share/icons/hicolor
+	gtk-update-icon-cache $(PREFIX)/share/icons/hicolor
+	glib-compile-schemas $(PREFIX)/share/glib-2.0/schemas/
 
 uninstall:
 	rm -f $(PREFIX)/bin/collision
+	rm -f $(PREFIX)/share/glib-2.0/schemas/dev.geopjr.Collision.gschema.xml
 	rm -f $(PREFIX)/share/applications/dev.geopjr.Collision.desktop
 	rm -f $(PREFIX)/share/icons/hicolor/scalable/apps/dev.geopjr.Collision.svg
 	rm -f $(PREFIX)/share/icons/hicolor/symbolic/apps/dev.geopjr.Collision-symbolic.svg
 	rm -rf $(PREFIX)$(LOCALE_LOCATION)/*/*/dev.geopjr.Collision.mo
-	gtk-update-icon-cache /usr/share/icons/hicolor
+	gtk-update-icon-cache $(PREFIX)/share/icons/hicolor

--- a/data/dev.geopjr.Collision.gschema.xml
+++ b/data/dev.geopjr.Collision.gschema.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<schemalist gettext-domain="dev.geopjr.Collision">
+	<schema id="dev.geopjr.Collision" path="/dev/geopjr/Collision/">
+		<key name="window-width" type="i">
+			<default>600</default>
+			<summary>Default window width</summary>
+		</key>
+		<key name="window-height" type="i">
+			<default>460</default>
+			<summary>Default window height</summary>
+		</key>
+		<key name="is-maximized" type="b">
+			<default>false</default>
+			<summary>Default window maximized state</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/data/dev.geopjr.Collision.json
+++ b/data/dev.geopjr.Collision.json
@@ -49,7 +49,7 @@
         "for i in ./lib/*/; do ln -snf \"..\" \"$i/lib\"; done",
         "cd lib/gi-crystal && crystal build src/generator/main.cr && cd ../.. && mkdir ./bin && cp lib/gi-crystal/main ./bin/gi-crystal",
         "./bin/gi-crystal",
-        "COLLISION_LOCALE_LOCATION=\"/app/share/locale\" crystal build -Dpreview_mt ./src/collision.cr #--no-debug --release",
+        "COLLISION_LOCALE_LOCATION=\"/app/share/locale\" crystal build -Dpreview_mt ./src/collision.cr -Denable_gschema #--no-debug --release",
         "msgfmt --xml --template data/dev.geopjr.Collision.metainfo.xml.in -d \"./po\" -o data/dev.geopjr.Collision.metainfo.xml",
         "msgfmt --desktop --template data/dev.geopjr.Collision.desktop.in -d \"./po\" -o data/dev.geopjr.Collision.desktop",
         "mkdir -p po/mo && for lang in `cat \"po/LINGUAS\"`; do if [[ \"$lang\" == 'en' || \"$lang\" == '' ]]; then continue; fi; mkdir -p \"/app/share/locale/$lang/LC_MESSAGES\"; msgfmt \"po/$lang.po\" -o \"po/mo/$lang.mo\";  install -D -m 0644 \"po/mo/$lang.mo\" \"/app/share/locale/$lang/LC_MESSAGES/dev.geopjr.Collision.mo\"; done"
@@ -59,7 +59,9 @@
         "install -D -m 0644 data/dev.geopjr.Collision.desktop /app/share/applications/dev.geopjr.Collision.desktop",
         "install -D -m 0644 data/icons/dev.geopjr.Collision.svg /app/share/icons/hicolor/scalable/apps/dev.geopjr.Collision.svg",
         "install -D -m 0644 data/icons/dev.geopjr.Collision-symbolic.svg /app/share/icons/hicolor/symbolic/apps/dev.geopjr.Collision-symbolic.svg",
-        "install -D -m 0644 data/dev.geopjr.Collision.metainfo.xml /app/share/metainfo/dev.geopjr.Collision.metainfo.xml"
+        "install -D -m 0644 data/dev.geopjr.Collision.metainfo.xml /app/share/metainfo/dev.geopjr.Collision.metainfo.xml",
+        "install -D -m 0644 data/dev.geopjr.Collision.gschema.xml /app/share/glib-2.0/schemas/dev.geopjr.Collision.gschema.xml",
+        "glib-compile-schemas /app/share/glib-2.0/schemas"
       ],
       "sources": [
         {

--- a/src/collision.cr
+++ b/src/collision.cr
@@ -11,6 +11,16 @@ end
 module Collision
   LOGGER = Log.for("Collision", ARGV[0]? == "--debug" ? Log::Severity::Debug : Log::Severity::Warn)
 
+  # We want to __not__ load settings on dev/debug mode or when -Ddisable_gschema is passed or when
+  # -Denable_gschema is __not__ passed.
+  # -Denable_gschema is used for when you are in dev/debug mode and want to enable it.
+  # -Ddisable_gschema is used for when you are in prod mode and want to disable it (for package maintainers).
+  SETTINGS = {% if (flag?(:debug) || !flag?(:release) || flag?(:disable_gschema)) && !flag?(:enable_gschema) %}
+               nil
+             {% else %}
+               Gio::Settings.new("dev.geopjr.Collision")
+             {% end %}
+
   begin
     Gettext.setlocale(Gettext::LC::ALL, "")
     Gettext.bindtextdomain("dev.geopjr.Collision", {{env("COLLISION_LOCALE_LOCATION").nil? ? "/usr/share/locale" : env("COLLISION_LOCALE_LOCATION")}})

--- a/src/collision/functions/settings.cr
+++ b/src/collision/functions/settings.cr
@@ -21,9 +21,11 @@ module Collision
 
   def settings_available?(settings : Gio::Settings) : Bool
     diff = SETTINGS_KEYS - settings.list_keys
-    LOGGER.debug { "Missing settings: #{diff}" }
+    missing = diff.empty?
 
-    diff.empty?
+    LOGGER.debug { "Missing settings: #{diff}" } unless missing
+
+    missing
   end
 
   def get_settings

--- a/src/collision/functions/settings.cr
+++ b/src/collision/functions/settings.cr
@@ -1,0 +1,60 @@
+# Handles gschema settings
+
+module Collision
+  extend self
+
+  DEFAULT_SETTINGS = {
+    window_width:     600,
+    window_height:    460,
+    window_maximized: false,
+  }
+
+  # Used to avoid a GLib error on runtime
+  # when a key doesn't exist for whatever
+  # reason.
+  # Settings keys used/required.
+  SETTINGS_KEYS = [
+    "window-width",
+    "window-height",
+    "is-maximized",
+  ]
+
+  def settings_available?(settings : Gio::Settings) : Bool
+    diff = SETTINGS_KEYS - settings.list_keys
+    LOGGER.debug { "Missing settings: #{diff}" }
+
+    diff.empty?
+  end
+
+  def get_settings
+    LOGGER.debug { "Loading settings" }
+
+    return DEFAULT_SETTINGS if (settings = SETTINGS).nil? || !settings_available?(settings)
+
+    begin
+      {
+        window_width:     settings.int("window-width"),
+        window_height:    settings.int("window-height"),
+        window_maximized: settings.boolean("is-maximized"),
+      }
+    rescue ex
+      LOGGER.debug { ex }
+
+      DEFAULT_SETTINGS
+    end
+  end
+
+  def save_settings(window : Gtk::Window) : Bool
+    LOGGER.debug { "Saving settings" }
+
+    return false if (settings = SETTINGS).nil? || !settings_available?(settings)
+
+    unless window.maximized?
+      settings.set_int("window-width", window.width)
+      settings.set_int("window-height", window.height)
+    end
+    settings.set_boolean("is-maximized", window.maximized?)
+
+    false
+  end
+end

--- a/src/collision/views/main.cr
+++ b/src/collision/views/main.cr
@@ -6,12 +6,18 @@ module Collision
     return main_window.present if main_window
 
     window = Adw::ApplicationWindow.new(app)
+    window_settings = Collision.get_settings
+
     window.name = "mainWindow"
     window.title = Gettext.gettext("Collision")
-    window.set_default_size(600, 460)
+    window.close_request_signal.connect(->Collision.save_settings(Gtk::Window))
     window.width_request = 360
     window.height_request = 360
+    window.set_default_size(window_settings[:window_width], window_settings[:window_height])
+
     @@main_window_id = window.id
+
+    window.maximize if window_settings[:window_maximized]
 
     Collision.generate_headbar
     root = Adw::StatusPage.cast(B_UI["welcomer"])
@@ -80,6 +86,7 @@ module Collision
     window.present
 
     LOGGER.debug { "Window activated" }
+    LOGGER.debug { "Settings: #{window_settings}" }
   end
 
   def startup(app : Adw::Application)
@@ -112,5 +119,6 @@ module Collision
 
   APP.startup_signal.connect(->startup(Adw::Application))
   APP.activate_signal.connect(->activate(Adw::Application))
+
   exit(APP.run(nil))
 end


### PR DESCRIPTION
for window settings (width, height, maximized)

# Package maintainers

If you depend on the `Makefile` you probably have nothing more to do.
If not, you now have to install a gschema and compile them (see Makefile).
If for some reason you don't want to deal with it, you can just pass `-Ddisable_gschema` during compile-time (Collision will work as expected, it just won't have any of the functions that depend on it (remembering window size and whether it is maximized))

# Developers & Testers

## Non-flatpak

On dev/debug mode gschema is disabled by default. You can force enable it by passing `-Denable_gschema` during compile-time, however you are also going to need to install the gschema (the errors will let you know).

## Flatpak

Nothing to do, gschema is enabled & installed.