### PR TITLE
Handle open signal

### DIFF
--- a/src/collision.cr
+++ b/src/collision.cr
@@ -145,5 +145,5 @@ module Collision
   FILE_INFO = Adw::StatusPage.cast(B_FI["fileInfo"])
   HASH_LIST = Gtk::ListBox.cast(B_HS["hashList"])
 
-  APP = Adw::Application.new("dev.geopjr.Collision", Gio::ApplicationFlags::None)
+  APP = Adw::Application.new("dev.geopjr.Collision", Gio::ApplicationFlags::HandlesOpen)
 end

--- a/src/collision/functions/file.cr
+++ b/src/collision/functions/file.cr
@@ -32,8 +32,8 @@ module Collision
     filepath.dirname.to_s
   end
 
-  def set_file(filepath : Path)
-    LOGGER.debug { "File set: #{filepath.to_s}" }
+  def file=(filepath : Path)
+    LOGGER.debug { "File set: \"#{filepath}\"" }
 
     FILE_INFO.title = filepath.basename.to_s
     FILE_INFO.description = real_path(filepath)
@@ -53,5 +53,32 @@ module Collision
       SPINNER.visible = false
       HEADER_TITLE.view_switcher_enabled = true
     end
+  end
+
+  # For Gio::File.
+  # Should be used instead of Collision#file=(filepath : Path)
+  # unless path is a File and exists.
+  def file=(file : Gio::File)
+    Collision.file?(file.path.not_nil!)
+
+    Collision::Feedback.reset
+
+    Collision.file = file.path.not_nil!
+  end
+
+  # Checks if path is a File and exists.
+  # If it doesn't, it will either raise an exception
+  # or just log an error based on the `exception` param.
+  def file?(file : Path | String, exception : Bool = true) : Bool
+    return true if File.file?(file)
+
+    msg = "\"#{file}\" does not exist or is not a File"
+    if exception
+      raise msg
+    else
+      LOGGER.debug { msg }
+    end
+
+    false
   end
 end

--- a/src/collision/views/main.cr
+++ b/src/collision/views/main.cr
@@ -98,8 +98,21 @@ module Collision
     TOOL_VERIFY_OVERLAY.child = scrolled_window
   end
 
+  def open_with(app : Adw::Application, files : Enumerable(Gio::File), hint : String)
+    activate(app)
+
+    if files.size >= 0 && Collision.file?(files[0].path.not_nil!, false)
+      Collision::Welcomer.file = files[0]
+    end
+
+    nil
+  end
+
   APP.startup_signal.connect(->startup(Adw::Application))
   APP.activate_signal.connect(->activate(Adw::Application))
+  APP.open_signal.connect(->open_with(Adw::Application, Enumerable(Gio::File), String))
 
-  exit(APP.run(nil))
+  # ARGV but without flags, passed to Application.
+  clean_argv = [PROGRAM_NAME].concat(ARGV.reject { |x| x.starts_with?('-') })
+  exit(APP.run(clean_argv))
 end

--- a/src/collision/views/main.cr
+++ b/src/collision/views/main.cr
@@ -98,10 +98,14 @@ module Collision
     TOOL_VERIFY_OVERLAY.child = scrolled_window
   end
 
+  # Handles the open signal. It first calls activate and then
+  # if there are files passed (that exist and are not dirs)
+  # it sets the first one (since multiple can be passed)
+  # as the Collision::Welcomer's file.
   def open_with(app : Adw::Application, files : Enumerable(Gio::File), hint : String)
     activate(app)
 
-    if files.size >= 0 && Collision.file?(files[0].path.not_nil!, false)
+    if files.size > 0 && Collision.file?(files[0].path.not_nil!, false)
       Collision::Welcomer.file = files[0]
     end
 

--- a/src/collision/views/main.cr
+++ b/src/collision/views/main.cr
@@ -34,9 +34,10 @@ module Collision
 
     MAIN_FILE_CHOOSER_NATIVE.response_signal.connect do |response|
       next unless response == -3
-      Collision::Feedback.reset
 
-      set_file(MAIN_FILE_CHOOSER_NATIVE.file.not_nil!.path.not_nil!)
+      Collision.file = MAIN_FILE_CHOOSER_NATIVE.file.not_nil!
+    rescue ex
+      LOGGER.debug { ex }
     end
 
     OPEN_FILE_BUTTON.clicked_signal.connect do

--- a/src/collision/views/tools/compare.cr
+++ b/src/collision/views/tools/compare.cr
@@ -8,28 +8,37 @@ module Collision::Compare
 
     TOOL_COMPARE_FILE_CHOOSER_NATIVE.response_signal.connect do |response|
       next unless response == -3
-      LOGGER.debug { "Begin comparing tool" }
 
-      TOOL_COMPARE_BUTTON_SPINNER.visible = true
-      TOOL_COMPARE_BUTTON_IMAGE.visible = false
-      TOOL_COMPARE_BUTTON.remove_css_class("success")
-      TOOL_COMPARE_BUTTON.remove_css_class("error")
+      Collision::Compare.file = TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.not_nil!
+    rescue ex
+      LOGGER.debug { ex }
+    end
+  end
 
-      TOOL_COMPARE_BUTTON_LABEL.label = TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.not_nil!.path.not_nil!.basename.to_s
-      Collision::Checksum.spawn do
-        compareFileSHA256 = Collision::Checksum.calculate("sha256", TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.not_nil!.path.to_s)
-        result = CLIPBOARD_HASH["SHA256"] == compareFileSHA256
-        classes = Collision::Feedback.class(result)
+  def file=(file : Gio::File)
+    LOGGER.debug { "Begin comparing tool" }
 
-        sleep 500.milliseconds
-        TOOL_COMPARE_BUTTON_SPINNER.visible = false
-        TOOL_COMPARE_BUTTON_IMAGE.visible = true
-        TOOL_COMPARE_BUTTON_IMAGE.icon_name = Collision::Feedback.icon(result)
-        TOOL_COMPARE_BUTTON.add_css_class(classes[:add])
-        TOOL_COMPARE_BUTTON.remove_css_class(classes[:remove])
+    Collision.file?(file.path.not_nil!)
 
-        LOGGER.debug { "Finished comparing tool" }
-      end
+    TOOL_COMPARE_BUTTON_SPINNER.visible = true
+    TOOL_COMPARE_BUTTON_IMAGE.visible = false
+    TOOL_COMPARE_BUTTON.remove_css_class("success")
+    TOOL_COMPARE_BUTTON.remove_css_class("error")
+
+    TOOL_COMPARE_BUTTON_LABEL.label = file.path.not_nil!.basename.to_s
+    Collision::Checksum.spawn do
+      compareFileSHA256 = Collision::Checksum.calculate("sha256", file.path.to_s)
+      result = CLIPBOARD_HASH["SHA256"] == compareFileSHA256
+      classes = Collision::Feedback.class(result)
+
+      sleep 500.milliseconds
+      TOOL_COMPARE_BUTTON_SPINNER.visible = false
+      TOOL_COMPARE_BUTTON_IMAGE.visible = true
+      TOOL_COMPARE_BUTTON_IMAGE.icon_name = Collision::Feedback.icon(result)
+      TOOL_COMPARE_BUTTON.add_css_class(classes[:add])
+      TOOL_COMPARE_BUTTON.remove_css_class(classes[:remove])
+
+      LOGGER.debug { "Finished comparing tool" }
     end
   end
 end

--- a/src/collision/views/welcomer.cr
+++ b/src/collision/views/welcomer.cr
@@ -1,5 +1,6 @@
 module Collision::Welcomer
   extend self
+  @@passed = false
 
   def init
     WELCOME_BUTTON.clicked_signal.connect do
@@ -8,11 +9,26 @@ module Collision::Welcomer
 
     WELCOMER_FILE_CHOOSER_NATIVE.response_signal.connect do |response|
       next unless response == -3
-      WINDOW_BOX.remove(Gtk::Widget.cast(B_UI["welcomer"]))
-      Collision.reset
 
-      Collision.set_file(WELCOMER_FILE_CHOOSER_NATIVE.file.not_nil!.path.not_nil!)
-      LOGGER.debug { "Passed welcomer" }
+      Collision::Welcomer.file = WELCOMER_FILE_CHOOSER_NATIVE.file.not_nil!
+    rescue ex
+      LOGGER.debug { ex }
     end
+  end
+
+  def file=(file : Gio::File)
+    Collision.file?(file.path.not_nil!)
+
+    WINDOW_BOX.remove(Gtk::Widget.cast(B_UI["welcomer"]))
+    Collision.reset
+
+    Collision.file = file.path.not_nil!
+    @@passed = true
+
+    LOGGER.debug { "Passed welcomer" }
+  end
+
+  def passed? : Bool
+    @@passed
   end
 end


### PR DESCRIPTION
This PR allows Collision to open files either from CLI:

```
$ collision ./my/file.txt
```

or through your file manager's "Open With..." context menu entry:

[Recording of a GNOME desktop with the Files app open. There's a file named test.txt. User right clicks it and selects the open with context entry. Afterwards, a popup to select the app to open it with shows up. User selects Collision. Then the Collision up shows up with that file's hashes.](https://user-images.githubusercontent.com/18014039/199318847-7abcab58-d9be-4735-bf2c-8bb50cec8d5d.webm)

Some changes to the way file setting works had to be upstreamed from the DnD PR (#115), which included some additional error handling and bug fixes.

As suggested partially in: #53 

