### PR TITLE
Update help overlay

### DIFF
--- a/data/dev.geopjr.Collision.gresource.xml
+++ b/data/dev.geopjr.Collision.gresource.xml
@@ -14,6 +14,6 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/switcher.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/tools.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/welcomer.ui</file>
-    <file compressed="true" preprocess="xml-stripblanks">ui/shortcuts_window.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts_window.ui</file>
   </gresource>
 </gresources>

--- a/data/ui/shortcuts_window.ui
+++ b/data/ui/shortcuts_window.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <object class="GtkShortcutsWindow" id="shortcuts_window">
+  <object class="GtkShortcutsWindow" id="help_overlay">
     <property name="modal">1</property>
     <child>
       <object class="GtkShortcutsSection">

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -5,5 +5,6 @@ data/ui/tools.ui
 data/ui/header_right.ui
 data/ui/header_left.ui
 data/ui/hash_list.ui
+data/ui/shortcuts_window.ui
 data/ui/switcher.ui
 data/ui/spinner.ui

--- a/src/collision.cr
+++ b/src/collision.cr
@@ -87,7 +87,6 @@ module Collision
   B_HT = Gtk::Builder.new_from_resource("/dev/geopjr/Collision/ui/switcher.ui")
   B_SP = Gtk::Builder.new_from_resource("/dev/geopjr/Collision/ui/spinner.ui")
   B_FI = Gtk::Builder.new_from_resource("/dev/geopjr/Collision/ui/file_info.ui")
-  B_SW = Gtk::Builder.new_from_resource("/dev/geopjr/Collision/ui/shortcuts_window.ui")
 
   WINDOW_BOX = Gtk::Box.new(Gtk::Orientation::Vertical, 0)
 
@@ -99,7 +98,6 @@ module Collision
   HEADER_TITLE                 = Adw::ViewSwitcherTitle.cast(B_HT["switcher_title"])
   BOTTOM_TABS                  = Adw::ViewSwitcherBar.cast(B_HT["switcher_bar"])
   STACK                        = Adw::ViewStack.cast(B_HT["stack"])
-  SHORTCUT_WINDOW              = Gtk::ShortcutsWindow.cast(B_SW["shortcuts_window"])
 
   SPINNER = Gtk::Spinner.new(
     spinning: true,

--- a/src/collision/views/main.cr
+++ b/src/collision/views/main.cr
@@ -45,9 +45,6 @@ module Collision
       MAIN_FILE_CHOOSER_NATIVE.show
     end
 
-    # Setup shortcuts window.
-    window.help_overlay = SHORTCUT_WINDOW
-
     # Setup actions.
     Collision::Action::About.new(app)
     Collision::Action::HashInfo.new(app, window.id)
@@ -57,7 +54,6 @@ module Collision
     # Setup accelerators.
     app.set_accels_for_action("app.quit", {"<Control>q", "<Control>w"})
     app.set_accels_for_action("app.open-file", {"<Control>o"})
-    app.set_accels_for_action("win.show-help-overlay", {"<Control>question"})
 
     # Setup clipboard.
     Collision::Clipboard.new(window, COPY_BUTTONS)


### PR DESCRIPTION
application: Use default GTK help-overlay
- GTK can handle help-overlay with some specifications.

data: Add shortcuts_window.ui to potfiles
- It was missing in POTFILES.