### PR TITLE
HeaderBar: Set centering_policy to strict

### DIFF
--- a/src/collision/functions/headbar.cr
+++ b/src/collision/functions/headbar.cr
@@ -13,6 +13,7 @@ module Collision
       headerbar.pack_start(open_file_button)
       headerbar.pack_end(menu_button)
       headerbar.title_widget = title
+      headerbar.centering_policy = Adw::CenteringPolicy::Strict
 
       @widget = headerbar
     end


### PR DESCRIPTION
I couldn't test this (The project somehow doesn't build for me in Builder), but it _should_ work.