### PR TITLE
data: Fix app description marked as untranslated

### DIFF
--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -10,7 +10,7 @@
   <url type="bugtracker">https://github.com/GeopJr/Collision/issues</url>
   <url type="translate">https://hosted.weblate.org/engage/collision/</url>
   <url type="donation">https://geopjr.dev/donate</url>
-  <description translatable="no">
+  <description>
     <p>
       Verifying that a file you downloaded or received is actually the one you were
       expecting is often overlooked or too time-consuming to do. At the same time, it


### PR DESCRIPTION
The descriptions under the Release tag don't necessarily need to be marked as translatable. However, this is the description of the application and can be seen in GNOME Software. So, leave it translatable.