### PR TITLE
appdata: add vcs-browser support

### DIFF
--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -10,6 +10,8 @@
   <url type="bugtracker">https://github.com/GeopJr/Collision/issues</url>
   <url type="translate">https://hosted.weblate.org/engage/collision/</url>
   <url type="donation">https://geopjr.dev/donate</url>
+  <url type="vcs-browser">https://github.com/GeopJr/Collision/</url>
+  <url type="contribute">https://github.com/GeopJr/Collision#contributing</url>
   <description>
     <p>
       Verifying that a file you downloaded or received is actually the one you were


### PR DESCRIPTION
These URL is visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url