### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -174,10 +174,6 @@
   </releases>
   <content_rating type="oars-1.1" />
   <translation type="gettext">dev.geopjr.Collision</translation>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
   <requires>
     <display_length compare="ge">360</display_length>
   </requires>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work

More information: https://github.com/ximion/appstream/issues/476