### PR TITLE
appdata: Add missing the `launchable` tag

### DIFF
--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -173,6 +173,10 @@
     <release version="1.0.1" date="2021-02-11" />
   </releases>
   <content_rating type="oars-1.1" />
+  <provides>
+    <binary>collision</binary>
+  </provides>
+  <launchable type="desktop-id">dev.geopjr.Collision.desktop</launchable>
   <translation type="gettext">dev.geopjr.Collision</translation>
   <requires>
     <display_length compare="ge">360</display_length>


### PR DESCRIPTION
This tag is optional but in use most of GNOME apps.

"This optional tag indicates possible methods to launch the software described in this component"

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable