### PR TITLE
feat: Blake3, CRC32, Adler32, progress bar, cleanup

### DIFF
--- a/data/dev.geopjr.Collision.desktop.in
+++ b/data/dev.geopjr.Collision.desktop.in
@@ -8,6 +8,6 @@ Comment=Check hashes for your files
 Terminal=false
 Icon=dev.geopjr.Collision
 Categories=Utility;
-Keywords=md5;sha1;sha256;sha512;hash;
+Keywords=md5;sha1;sha256;sha512;blake3;crc32;adler32;hash;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/dev.geopjr.Collision.gresource.xml
+++ b/data/dev.geopjr.Collision.gresource.xml
@@ -8,6 +8,7 @@
     <file compressed="true" preprocess="xml-stripblanks" alias="icons/scalable/actions/octothorp-symbolic.svg">icons/octothorp-symbolic.svg</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="icons/scalable/actions/paper-symbolic.svg">icons/paper-symbolic.svg</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/application.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/hash_row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts_window.ui</file>
   </gresource>
 </gresources>

--- a/data/dev.geopjr.Collision.json
+++ b/data/dev.geopjr.Collision.json
@@ -47,9 +47,10 @@
       },
       "build-commands": [
         "for i in ./lib/*/; do ln -snf \"..\" \"$i/lib\"; done",
+        "cd lib/blake3/blake3c && make -f ../build/Makefile && cd ../../..",
         "cd lib/gi-crystal && crystal build src/generator/main.cr && cd ../.. && mkdir ./bin && cp lib/gi-crystal/main ./bin/gi-crystal",
         "./bin/gi-crystal",
-        "COLLISION_LOCALE_LOCATION=\"/app/share/locale\" crystal build -Dpreview_mt ./src/collision.cr -Denable_gschema #--no-debug --release",
+        "COLLISION_LOCALE_LOCATION=\"/app/share/locale\" crystal build -Dpreview_mt ./src/collision.cr -Denable_gschema --release #--no-debug",
         "msgfmt --xml --template data/dev.geopjr.Collision.metainfo.xml.in -d \"./po\" -o data/dev.geopjr.Collision.metainfo.xml",
         "msgfmt --desktop --template data/dev.geopjr.Collision.desktop.in -d \"./po\" -o data/dev.geopjr.Collision.desktop",
         "mkdir -p po/mo && for lang in `cat \"po/LINGUAS\"`; do if [[ \"$lang\" == 'en' || \"$lang\" == '' ]]; then continue; fi; mkdir -p \"/app/share/locale/$lang/LC_MESSAGES\"; msgfmt \"po/$lang.po\" -o \"po/mo/$lang.mo\";  install -D -m 0644 \"po/mo/$lang.mo\" \"/app/share/locale/$lang/LC_MESSAGES/dev.geopjr.Collision.mo\"; done"
@@ -81,8 +82,8 @@
         {
           "type": "archive",
           "dest": "crystal/",
-          "url": "https://github.com/crystal-lang/crystal/releases/download/1.9.2/crystal-1.9.2-1-linux-x86_64.tar.gz",
-          "sha256": "2dcfa020763998550904d6d8ea3eb178a1d93e8d7fea0f61d8c80c2b8fce9e24",
+          "url": "https://github.com/crystal-lang/crystal/releases/download/1.10.1/crystal-1.10.1-1-linux-x86_64.tar.gz",
+          "sha256": "1742e3755d3653d1ba07c0291f10a517fa392af87130dba4497ed9d82c12348b",
           "only_arches": [
             "x86_64"
           ]
@@ -98,6 +99,12 @@
         },
         {
           "type": "git",
+          "url": "https://github.com/geopjr/blake3.cr.git",
+          "tag": "v1.2.0",
+          "dest": "lib/blake3"
+        },
+        {
+          "type": "git",
           "url": "https://github.com/geopjr/gettext.cr.git",
           "tag": "v1.0.0",
           "dest": "lib/gettext"
@@ -105,19 +112,13 @@
         {
           "type": "git",
           "url": "https://github.com/hugopl/gi-crystal.git",
-          "tag": "v0.18.0",
+          "tag": "v0.21.0",
           "dest": "lib/gi-crystal"
         },
         {
           "type": "git",
-          "url": "https://github.com/hugopl/gio.cr.git",
-          "tag": "v0.1.0",
-          "dest": "lib/gio"
-        },
-        {
-          "type": "git",
           "url": "https://github.com/hugopl/gtk4.cr.git",
-          "tag": "v0.15.0",
+          "tag": "v0.16.0",
           "dest": "lib/gtk4"
         },
         {
@@ -141,7 +142,7 @@
         {
           "type": "git",
           "url": "https://github.com/hugopl/pango.cr.git",
-          "tag": "v0.2.0",
+          "tag": "v0.3.1",
           "dest": "lib/pango"
         }
       ]

--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -22,7 +22,7 @@
     <p>
       This tool aims to solve that. Collision comes with a simple &amp; clean UI, allowing
       anyone, from any age and experience group, to generate, compare and verify MD5,
-      SHA-256, SHA-512 and SHA-1 hashes.
+      SHA-256, SHA-512, SHA-1, Blake3, CRC32 and Adler32 hashes.
     </p>
   </description>
   <screenshots>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -134,14 +134,23 @@
 							<object class="GtkStackPage">
 								<property name="name">spinner</property>
 								<property name="child">
-									<object class="GtkSpinner">
-										<property name="valign">center</property>
-										<property name="halign">center</property>
-										<property name="hexpand">1</property>
-										<property name="vexpand">1</property>
-										<property name="spinning">1</property>
-										<property name="width-request">32</property>
-										<property name="height-request">32</property>
+									<object class="AdwStatusPage">
+										<property name="title" translatable="yes">Calculating Hashes</property>
+										<property name="description" translatable="yes">This might take a while</property>
+										<child>
+											<object class="AdwClamp">
+												<property name="tightening-threshold">100</property>
+												<property name="maximum-size">400</property>
+												<child>
+													<object class="GtkProgressBar" id="progressbar">
+														<property name="show-text">1</property>
+														<property name="valign">center</property>
+														<property name="hexpand">1</property>
+														<property name="vexpand">1</property>
+													</object>
+												</child>
+											</object>
+										</child>
 									</object>
 								</property>
 							</object>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -27,7 +27,7 @@
 		<property name="title" translatable="yes">Choose a File</property>
 		<property name="modal">1</property>
 	</object>
-	<template class="CollisionWindow" parent="AdwApplicationWindow">
+	<template class="Collision-Window" parent="AdwApplicationWindow">
 		<property name="width-request">360</property>
 		<property name="height-request">360</property>
 		<property name="title" translatable="yes">Collision</property>
@@ -165,89 +165,9 @@
 																<property name="title" translatable="yes">Hash</property>
 																<property name="icon-name">octothorp-symbolic</property>
 																<property name="child">
-																	<object class="GtkListBox">
+																	<object class="GtkListBox" id="hash_row_container">
 																		<property name="halign">center</property>
 																		<property name="valign">center</property>
-																		<child>
-																			<object class="AdwActionRow" id="MD5_row">
-																				<property name="title">MD5</property>
-																				<property name="selectable">0</property>
-																				<property name="subtitle-lines">100</property>
-																				<child>
-																					<object class="GtkButton" id="MD5_btn">
-																						<property name="tooltip-text" translatable="yes">Copy</property>
-																						<property name="icon-name">edit-copy-symbolic</property>
-																						<property name="valign">center</property>
-																						<style>
-																							<class name="circular" />
-																						</style>
-																					</object>
-																				</child>
-																				<style>
-																					<class name="hash-row" />
-																				</style>
-																			</object>
-																		</child>
-																		<child>
-																			<object class="AdwActionRow" id="SHA1_row">
-																				<property name="title">SHA-1</property>
-																				<property name="selectable">0</property>
-																				<property name="subtitle-lines">100</property>
-																				<child>
-																					<object class="GtkButton" id="SHA1_btn">
-																						<property name="tooltip-text" translatable="yes">Copy</property>
-																						<property name="icon-name">edit-copy-symbolic</property>
-																						<property name="valign">center</property>
-																						<style>
-																							<class name="circular" />
-																						</style>
-																					</object>
-																				</child>
-																				<style>
-																					<class name="hash-row" />
-																				</style>
-																			</object>
-																		</child>
-																		<child>
-																			<object class="AdwActionRow" id="SHA256_row">
-																				<property name="title">SHA-256</property>
-																				<property name="selectable">0</property>
-																				<property name="subtitle-lines">100</property>
-																				<child>
-																					<object class="GtkButton" id="SHA256_btn">
-																						<property name="tooltip-text" translatable="yes">Copy</property>
-																						<property name="icon-name">edit-copy-symbolic</property>
-																						<property name="valign">center</property>
-																						<style>
-																							<class name="circular" />
-																						</style>
-																					</object>
-																				</child>
-																				<style>
-																					<class name="hash-row" />
-																				</style>
-																			</object>
-																		</child>
-																		<child>
-																			<object class="AdwActionRow" id="SHA512_row">
-																				<property name="title">SHA-512</property>
-																				<property name="selectable">0</property>
-																				<property name="subtitle-lines">100</property>
-																				<child>
-																					<object class="GtkButton" id="SHA512_btn">
-																						<property name="tooltip-text" translatable="yes">Copy</property>
-																						<property name="icon-name">edit-copy-symbolic</property>
-																						<property name="valign">center</property>
-																						<style>
-																							<class name="circular" />
-																						</style>
-																					</object>
-																				</child>
-																				<style>
-																					<class name="hash-row" />
-																				</style>
-																			</object>
-																		</child>
 																		<style>
 																			<class name="content" />
 																		</style>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -22,6 +22,7 @@
 	<object class="GtkFileChooserNative" id="mainFileChooserNative">
 		<property name="title" translatable="yes">Choose a File</property>
 		<property name="modal">1</property>
+		<property name="select-multiple">1</property>
 	</object>
 	<object class="GtkFileChooserNative" id="compareBtnFileChooserNative">
 		<property name="title" translatable="yes">Choose a File</property>

--- a/data/ui/application.ui
+++ b/data/ui/application.ui
@@ -216,6 +216,7 @@
 																				</child>
 																				<child>
 																					<object class="GtkOverlay">
+																						<property name="overflow">hidden</property>
 																						<child type="overlay">
 																							<object class="GtkImage" id="verifyFeedback">
 																								<property name="pixel-size">16</property>
@@ -230,7 +231,7 @@
 																						</child>
 																						<child type="overlay">
 																							<object class="GtkLabel" id="verifyOverlayLabel">
-																								<property name="label" translatable="yes">MD5,SHA-1,SHA-256 or SHA-512 Hash</property>
+																								<property name="label" translatable="yes">MD5,SHA-1,SHA-256,SHA-512,Blake3,CRC32 or Adler32 Hash</property>
 																								<property name="halign">start</property>
 																								<property name="valign">start</property>
 																								<property name="justify">fill</property>
@@ -259,7 +260,7 @@
 																										<property name="wrap-mode">char</property>
 																										<property name="accepts-tab">0</property>
 																										<property name="css-name">entry</property>
-																										<property name="tooltip-text" translatable="yes">Insert a MD5/SHA-1/SHA-256/SHA-512 Hash</property>
+																										<property name="tooltip-text" translatable="yes">Insert a MD5/SHA-1/SHA-256/SHA-512/Blake3/CRC32/Adler32 Hash</property>
 																										<style>
 																											<class name="card-like" />
 																											<class name="monospace" />

--- a/data/ui/hash_row.ui
+++ b/data/ui/hash_row.ui
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+	<requires lib="gtk" version="4.0" />
+	<template class="Collision-Widgets-HashRow" parent="AdwActionRow">
+		<property name="selectable">0</property>
+		<property name="subtitle-lines">100</property>
+		<child>
+			<object class="GtkButton" id="copy_btn">
+				<property name="tooltip-text" translatable="yes">Copy</property>
+				<property name="icon-name">edit-copy-symbolic</property>
+				<property name="valign">center</property>
+				<style>
+					<class name="circular" />
+				</style>
+			</object>
+		</child>
+		<style>
+			<class name="hash-row" />
+		</style>
+	</template>
+</interface>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,4 +1,5 @@
 data/dev.geopjr.Collision.desktop.in
 data/dev.geopjr.Collision.metainfo.xml.in
 data/ui/application.ui
+data/ui/hash_row.ui
 data/ui/shortcuts_window.ui

--- a/po/dev.geopjr.Collision.pot
+++ b/po/dev.geopjr.Collision.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-23 21:06+0300\n"
+"POT-Creation-Date: 2023-12-26 04:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,8 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/dev.geopjr.Collision.desktop.in:6
-#: data/dev.geopjr.Collision.metainfo.xml.in:4 data/ui/application.ui:33
-#: data/ui/application.ui:76 data/ui/application.ui:113
+#: data/dev.geopjr.Collision.metainfo.xml.in:4 data/ui/application.ui:34
+#: data/ui/application.ui:77 data/ui/application.ui:114
 msgid "Collision"
 msgstr ""
 
@@ -28,15 +28,15 @@ msgid "Hash Generator"
 msgstr ""
 
 #: data/dev.geopjr.Collision.desktop.in:8
-#: data/dev.geopjr.Collision.metainfo.xml.in:7 data/ui/application.ui:114
+#: data/dev.geopjr.Collision.metainfo.xml.in:7 data/ui/application.ui:115
 msgid "Check hashes for your files"
 msgstr ""
 
 #: data/dev.geopjr.Collision.desktop.in:12
-msgid "md5;sha1;sha256;sha512;hash;"
+msgid "md5;sha1;sha256;sha512;blake3;crc32;adler32;hash;"
 msgstr ""
 
-#: data/dev.geopjr.Collision.metainfo.xml.in:14
+#: data/dev.geopjr.Collision.metainfo.xml.in:16
 msgid ""
 "Verifying that a file you downloaded or received is actually the one you "
 "were expecting is often overlooked or too time-consuming to do. At the same "
@@ -45,11 +45,11 @@ msgid ""
 "actors."
 msgstr ""
 
-#: data/dev.geopjr.Collision.metainfo.xml.in:20
+#: data/dev.geopjr.Collision.metainfo.xml.in:22
 msgid ""
 "This tool aims to solve that. Collision comes with a simple &amp; clean UI, "
 "allowing anyone, from any age and experience group, to generate, compare and "
-"verify MD5, SHA-256, SHA-512 and SHA-1 hashes."
+"verify MD5, SHA-256, SHA-512, SHA-1, Blake3, CRC32 and Adler32 hashes."
 msgstr ""
 
 #: data/ui/application.ui:6
@@ -68,61 +68,68 @@ msgstr ""
 msgid "_About Collision"
 msgstr ""
 
-#: data/ui/application.ui:23 data/ui/application.ui:27
+#: data/ui/application.ui:23 data/ui/application.ui:28
 msgid "Choose a File"
 msgstr ""
 
-#: data/ui/application.ui:59
+#: data/ui/application.ui:60
 msgid "_Open"
 msgstr ""
 
-#: data/ui/application.ui:60
+#: data/ui/application.ui:61
 msgid "Open…"
 msgstr ""
 
-#: data/ui/application.ui:97
+#: data/ui/application.ui:98
 msgid "Menu"
 msgstr ""
 
-#: data/ui/application.ui:118
+#: data/ui/application.ui:119
 msgid "_Open a File"
 msgstr ""
 
-#: data/ui/application.ui:165
+#: data/ui/application.ui:139
+msgid "Calculating Hashes"
+msgstr ""
+
+#: data/ui/application.ui:140
+msgid "This might take a while"
+msgstr ""
+
+#: data/ui/application.ui:175
 msgid "Hash"
 msgstr ""
 
-#: data/ui/application.ui:178 data/ui/application.ui:198
-#: data/ui/application.ui:218 data/ui/application.ui:238
-msgid "Copy"
-msgstr ""
-
-#: data/ui/application.ui:261
+#: data/ui/application.ui:191
 msgid "Verify"
 msgstr ""
 
-#: data/ui/application.ui:274
+#: data/ui/application.ui:204
 msgid "Checksum"
 msgstr ""
 
-#: data/ui/application.ui:303
-msgid "MD5,SHA-1,SHA-256 or SHA-512 Hash"
+#: data/ui/application.ui:234
+msgid "MD5,SHA-1,SHA-256,SHA-512,Blake3,CRC32 or Adler32 Hash"
 msgstr ""
 
-#: data/ui/application.ui:332
-msgid "Insert a MD5/SHA-1/SHA-256/SHA-512 Hash"
+#: data/ui/application.ui:263
+msgid "Insert a MD5/SHA-1/SHA-256/SHA-512/Blake3/CRC32/Adler32 Hash"
 msgstr ""
 
-#: data/ui/application.ui:354
+#: data/ui/application.ui:285
 msgid "File"
 msgstr ""
 
-#: data/ui/application.ui:369
+#: data/ui/application.ui:300
 msgid "Select Another File to Check Against"
 msgstr ""
 
-#: data/ui/application.ui:411
+#: data/ui/application.ui:342
 msgid "Choose File…"
+msgstr ""
+
+#: data/ui/hash_row.ui:9
+msgid "Copy"
 msgstr ""
 
 #: data/ui/shortcuts_window.ui:11
@@ -154,7 +161,7 @@ msgid "Check Hashes"
 msgstr ""
 
 #. Wikipedia article. If available, set it to the LANGUAGE's version, else leave it as is.
-#: src/collision.cr:64
+#: src/collision.cr:72
 msgid ""
 "https://en.wikipedia.org/wiki/Comparison_of_cryptographic_hash_functions"
 msgstr ""
@@ -162,4 +169,10 @@ msgstr ""
 #. Name <email@domain.com> or Name https://website.example
 #: src/collision/actions/about.cr:22
 msgid "translator-credits"
+msgstr ""
+
+#. The variables are numbers
+#: src/collision/functions/checksum.cr:79
+#, c-format
+msgid "%d of %d hashes calculated"
 msgstr ""

--- a/shard.lock
+++ b/shard.lock
@@ -1,12 +1,16 @@
 version: 2.0
 shards:
+  blake3:
+    git: https://github.com/didactic-drunk/blake3.cr.git
+    version: 1.1.0
+
   gettext:
     git: https://github.com/geopjr/gettext.cr.git
     version: 1.0.0
 
   gi-crystal:
     git: https://github.com/hugopl/gi-crystal.git
-    version: 0.18.0
+    version: 0.19.0
 
   gio:
     git: https://github.com/hugopl/gio.cr.git
@@ -30,5 +34,5 @@ shards:
 
   pango:
     git: https://github.com/hugopl/pango.cr.git
-    version: 0.2.0
+    version: 0.3.0
 

--- a/shard.lock
+++ b/shard.lock
@@ -1,8 +1,8 @@
 version: 2.0
 shards:
   blake3:
-    git: https://github.com/didactic-drunk/blake3.cr.git
-    version: 1.1.0
+    git: https://github.com/geopjr/blake3.cr.git
+    version: 1.2.0
 
   gettext:
     git: https://github.com/geopjr/gettext.cr.git
@@ -10,15 +10,11 @@ shards:
 
   gi-crystal:
     git: https://github.com/hugopl/gi-crystal.git
-    version: 0.19.0
-
-  gio:
-    git: https://github.com/hugopl/gio.cr.git
-    version: 0.1.0
+    version: 0.21.0
 
   gtk4:
     git: https://github.com/hugopl/gtk4.cr.git
-    version: 0.15.0
+    version: 0.16.0
 
   harfbuzz:
     git: https://github.com/hugopl/harfbuzz.cr.git
@@ -34,5 +30,5 @@ shards:
 
   pango:
     git: https://github.com/hugopl/pango.cr.git
-    version: 0.3.0
+    version: 0.3.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -19,8 +19,8 @@ dependencies:
     github: GeopJr/gettext.cr
     version: ~> 1.0.0
   blake3:
-    github: didactic-drunk/blake3.cr
-    version: ~> 1.1.0
+    github: GeopJr/blake3.cr
+    version: ~> 1.2.0
 
 crystal: 1.9.2
 

--- a/shard.yml
+++ b/shard.yml
@@ -18,6 +18,9 @@ dependencies:
   gettext:
     github: GeopJr/gettext.cr
     version: ~> 1.0.0
+  blake3:
+    github: didactic-drunk/blake3.cr
+    version: ~> 1.1.0
 
 crystal: 1.9.2
 

--- a/spec/compare_spec.cr
+++ b/spec/compare_spec.cr
@@ -3,6 +3,6 @@ require "../src/collision/functions/file_utils.cr"
 
 describe Collision::FileUtils do
   it "returns whether the file contains one of the hashes" do
-    Collision::FileUtils.compare_content(Path[__DIR__] / "test_content.txt", Collision::CLIPBOARD_HASH.values.to_a).should be_true
+    Collision::FileUtils.compare_content(Path[__DIR__] / "test_content.txt", Collision::CLIPBOARD_HASH.values).should be_true
   end
 end

--- a/spec/compare_spec.cr
+++ b/spec/compare_spec.cr
@@ -3,6 +3,6 @@ require "../src/collision/functions/file_utils.cr"
 
 describe Collision::FileUtils do
   it "returns whether the file contains one of the hashes" do
-    Collision::FileUtils.compare_content(Path[__DIR__] / "test_content.txt", Collision::CLIPBOARD_HASH.values).should be_true
+    Collision::FileUtils.compare_content(Path[__DIR__] / "test_content.txt", Collision::CLIPBOARD_HASH.values.to_a).should be_true
   end
 end

--- a/spec/hash_generator_spec.cr
+++ b/spec/hash_generator_spec.cr
@@ -8,8 +8,8 @@ describe Collision::Checksum do
     channel = Channel(Hash(String, String)).new
 
     Collision::CLIPBOARD_HASH.keys.each do |x|
-      Collision::Checksum.spawn do
-        hashes[x] = Collision::Checksum.calculate(x, path.to_s)
+      Collision.spawn do
+        hashes[x] = Collision::Checksum.new.calculate(x, path.to_s)
       end
     end
 
@@ -25,6 +25,6 @@ describe Collision::Checksum do
 
   it "splits strings by 4" do
     input_by_4 = "Wait ingf orso meth ingt ohap pen?"
-    Collision::Checksum.split_by_4(input_by_4.split(' ').join).should eq(input_by_4)
+    Collision.split_by_4(input_by_4.split(' ').join).should eq(input_by_4)
   end
 end

--- a/spec/hash_generator_spec.cr
+++ b/spec/hash_generator_spec.cr
@@ -4,11 +4,10 @@ require "../src/collision/functions/checksum.cr"
 describe Collision::Checksum do
   it "gets hashes from file" do
     path = Path["./spec/test.txt"].expand(home: true)
-    hashes = Hash(String, String).new
+    hashes = Hash(Symbol, String).new
     channel = Channel(Hash(String, String)).new
-    hash_functions = ["sha512", "sha256", "md5", "sha1"]
 
-    hash_functions.each do |x|
+    Collision::CLIPBOARD_HASH.keys.each do |x|
       Collision::Checksum.spawn do
         hashes[x] = Collision::Checksum.calculate(x, path.to_s)
       end
@@ -16,10 +15,10 @@ describe Collision::Checksum do
 
     safe_stop = Time.utc.to_unix_ms
     loop do
-      break if hash_functions.size == hashes.size || Time.utc.to_unix_ms - safe_stop > 3000
+      break if Collision::CLIPBOARD_HASH.size == hashes.size || Time.utc.to_unix_ms - safe_stop > 3000
     end
 
-    hashes.should eq(Collision::CLIPBOARD_HASH)
+    hashes.should eq(Collision::CLIPBOARD_HASH.to_h)
   end
 
   it "splits strings by 4" do

--- a/spec/hash_generator_spec.cr
+++ b/spec/hash_generator_spec.cr
@@ -18,7 +18,9 @@ describe Collision::Checksum do
       break if Collision::CLIPBOARD_HASH.size == hashes.size || Time.utc.to_unix_ms - safe_stop > 3000
     end
 
-    hashes.should eq(Collision::CLIPBOARD_HASH.to_h)
+    Collision::CLIPBOARD_HASH.each do |k, v|
+      {k, hashes[k]}.should eq({k, v})
+    end
   end
 
   it "splits strings by 4" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -15,12 +15,12 @@ module Collision
     adler32: "Adler32",
   }
   CLIPBOARD_HASH = {
-    md5:     "f7e3f382f0382147661c82af20e274e8",
-    sha1:    "c8f0b71214e8164aa69419b7ac0bcd8a74f529a6",
-    sha256:  "08e3dfc089e66c44ae8abd3476b0f810f11f4cfc2ab925f1607c7df21345d639",
-    sha512:  "2ddb9cca7753a01fcbcdbacc228ae8c314ff4e735c6fffb42286272fb460930dc74f122a9f365053a13016b22403ad4e192142e8668bc5f7d6fce865eb38ec2c",
-    blake3:  "8a69892f0946333dbf909ecb68866d2f7116b7ba18ee7f2421afd705f9383cfc",
-    crc32:   "592339ec",
-    adler32: "1ba80397",
+    :md5     => "f7e3f382f0382147661c82af20e274e8",
+    :sha1    => "c8f0b71214e8164aa69419b7ac0bcd8a74f529a6",
+    :sha256  => "08e3dfc089e66c44ae8abd3476b0f810f11f4cfc2ab925f1607c7df21345d639",
+    :sha512  => "2ddb9cca7753a01fcbcdbacc228ae8c314ff4e735c6fffb42286272fb460930dc74f122a9f365053a13016b22403ad4e192142e8668bc5f7d6fce865eb38ec2c",
+    :blake3  => "8a69892f0946333dbf909ecb68866d2f7116b7ba18ee7f2421afd705f9383cfc",
+    :crc32   => "592339ec",
+    :adler32 => "1ba80397",
   }
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -5,11 +5,22 @@ require "log"
 
 module Collision
   LOGGER         = Log.for("Collision", Log::Severity::None)
-  HASH_FUNCTIONS = {"MD5", "SHA1", "SHA256", "SHA512"}
+  HASH_FUNCTIONS = {
+    md5:     "MD5",
+    sha1:    "SHA1",
+    sha256:  "SHA256",
+    sha512:  "SHA512",
+    blake3:  "Blake3",
+    crc32:   "CRC32",
+    adler32: "Adler32",
+  }
   CLIPBOARD_HASH = {
-    "md5"    => "f7e3f382f0382147661c82af20e274e8",
-    "sha1"   => "c8f0b71214e8164aa69419b7ac0bcd8a74f529a6",
-    "sha256" => "08e3dfc089e66c44ae8abd3476b0f810f11f4cfc2ab925f1607c7df21345d639",
-    "sha512" => "2ddb9cca7753a01fcbcdbacc228ae8c314ff4e735c6fffb42286272fb460930dc74f122a9f365053a13016b22403ad4e192142e8668bc5f7d6fce865eb38ec2c",
+    md5:     "f7e3f382f0382147661c82af20e274e8",
+    sha1:    "c8f0b71214e8164aa69419b7ac0bcd8a74f529a6",
+    sha256:  "08e3dfc089e66c44ae8abd3476b0f810f11f4cfc2ab925f1607c7df21345d639",
+    sha512:  "2ddb9cca7753a01fcbcdbacc228ae8c314ff4e735c6fffb42286272fb460930dc74f122a9f365053a13016b22403ad4e192142e8668bc5f7d6fce865eb38ec2c",
+    blake3:  "8a69892f0946333dbf909ecb68866d2f7116b7ba18ee7f2421afd705f9383cfc",
+    crc32:   "592339ec",
+    adler32: "1ba80397",
   }
 end

--- a/src/collision.cr
+++ b/src/collision.cr
@@ -58,8 +58,16 @@ module Collision
     LOGGER.debug { ex }
   end
 
-  HASH_FUNCTIONS = {"MD5", "SHA1", "SHA256", "SHA512"}
-  VERSION        = {{read_file("#{__DIR__}/../shard.yml").split("version: ")[1].split("\n")[0]}} # Shards binary might not be in PATH, reading yml is safer
+  HASH_FUNCTIONS = {
+    md5:     "MD5",
+    sha1:    "SHA1",
+    sha256:  "SHA256",
+    sha512:  "SHA512",
+    blake3:  "Blake3",
+    crc32:   "CRC32",
+    adler32: "Adler32",
+  }
+  VERSION = {{read_file("#{__DIR__}/../shard.yml").split("version: ")[1].split("\n")[0]}} # Shards binary might not be in PATH, reading yml is safer
 
   ARTICLE = Gettext.gettext("https://en.wikipedia.org/wiki/Comparison_of_cryptographic_hash_functions")
 
@@ -70,7 +78,7 @@ require "./collision/*"
 
 # Creates and setups a window. If a file is passed it will attempt to open it.
 def activate_with_file(app : Adw::Application, file : Gio::File? = nil)
-  window = CollisionWindow.new
+  window = Collision::Window.new
   window.application = app
 
   # Save settings on close

--- a/src/collision.cr
+++ b/src/collision.cr
@@ -109,6 +109,7 @@ def activate_with_file(app : Adw::Application, file : Gio::File? = nil)
   unless file.nil?
     Collision::LOGGER.debug { "Activating with file" }
 
+    window.loading
     window.file = file
   end
 end
@@ -133,10 +134,10 @@ def open_with(app : Adw::Application, files : Enumerable(Gio::File), hint : Stri
 end
 
 def open_files(app : Adw::Application, files : Enumerable(Gio::File))
-    files.each do |file|
-      next unless !(file_path = file.path).nil? && Collision::FileUtils.file?(file_path)
-      activate_with_file(app, file)
-    end
+  files.each do |file|
+    next unless !(file_path = file.path).nil? && Collision::FileUtils.file?(file_path)
+    activate_with_file(app, file)
+  end
 end
 
 app = Adw::Application.new("dev.geopjr.Collision", Gio::ApplicationFlags::HandlesOpen)

--- a/src/collision.cr
+++ b/src/collision.cr
@@ -123,16 +123,20 @@ end
 # If there are no files passed, it calls activate,
 # else it calls activate_with_file for each file
 def open_with(app : Adw::Application, files : Enumerable(Gio::File), hint : String)
-  if files.size == 0
+  if files.empty?
     activate(app)
   else
+    open_files(app, files)
+  end
+
+  nil
+end
+
+def open_files(app : Adw::Application, files : Enumerable(Gio::File))
     files.each do |file|
       next unless !(file_path = file.path).nil? && Collision::FileUtils.file?(file_path)
       activate_with_file(app, file)
     end
-  end
-
-  nil
 end
 
 app = Adw::Application.new("dev.geopjr.Collision", Gio::ApplicationFlags::HandlesOpen)

--- a/src/collision/functions/checksum.cr
+++ b/src/collision/functions/checksum.cr
@@ -15,13 +15,8 @@ macro gen_digest
   }
 end
 
-module Collision::Checksum
-  extend self
-
-  @@digest = gen_digest
-  @@channel = Channel(Tuple(Symbol, String)).new
-
-  def split_by_4(hash_str : String)
+module Collision
+  def self.split_by_4(hash_str : String)
     i = 0
     input = hash_str.byte_slice?(i * 4, 4)
     String.build do |str|
@@ -35,50 +30,58 @@ module Collision::Checksum
     end
   end
 
-  def calculate(type : Symbol, filename : String) : String
-    hash = @@digest[type]
-    hash.reset
-    hash.file(filename).final.hexstring.downcase
-  end
-
-  def spawn(&block)
+  def self.spawn(&block)
     Non::Blocking.spawn(same_thread: false, &block)
   end
 
-  def on_finished(res : Hash(Symbol, String), &block)
-    yield res
-  end
+  class Checksum
+    @digest = gen_digest
+    @channel = Channel(Tuple(Symbol, String)).new
 
-  def generate(filename : String, progressbar : Gtk::ProgressBar? = nil, &block : Hash(Symbol, String) ->)
-    hash_amount = Collision::HASH_FUNCTIONS.size
-    Collision::HASH_FUNCTIONS.each_with_index do |hash_key, hash_value, i|
-      proc = ->(fiber_no : Int32) do
-        Collision::Checksum.spawn do
-          LOGGER.debug { "Spawned fiber #{hash_value}" }
-
-          hash_value = calculate(hash_key, filename)
-          LOGGER.debug { "Finished fiber #{fiber_no + 1}/#{hash_amount}" }
-
-          @@channel.send({hash_key, hash_value})
-        end
-      end
-      proc.call(i)
+    def initialize
     end
 
-    Collision::Checksum.spawn do
-      res = Hash(Symbol, String).new
-      step = 1/hash_amount
-      hash_amount.times do |i|
-        t_res = @@channel.receive
-        res[t_res[0]] = t_res[1]
+    def calculate(type : Symbol, filename : String) : String
+      hash = @digest[type]
+      hash.reset
+      hash.file(filename).hexfinal.downcase
+    end
 
-        unless progressbar.nil?
-          progressbar.fraction = Math.min(progressbar.fraction + step, 1.0)
-          progressbar.text = sprintf(Gettext.gettext("%d of %d hashes calculated"), {i + 1, hash_amount})
+    def on_finished(res : Hash(Symbol, String), &block)
+      yield res
+    end
+
+    def generate(filename : String, progressbar : Gtk::ProgressBar? = nil, &block : Hash(Symbol, String) ->)
+      hash_amount = Collision::HASH_FUNCTIONS.size
+      Collision::HASH_FUNCTIONS.each_with_index do |hash_key, hash_value, i|
+        proc = ->(fiber_no : Int32) do
+          Collision.spawn do
+            LOGGER.debug { "Spawned fiber #{hash_value}" }
+
+            hash_value = calculate(hash_key, filename)
+            LOGGER.debug { "Finished fiber #{fiber_no + 1}/#{hash_amount}" }
+
+            @channel.send({hash_key, hash_value})
+          end
         end
+        proc.call(i)
       end
 
-      on_finished(res, &block)
+      Collision.spawn do
+        res = Hash(Symbol, String).new
+        step = 1/hash_amount
+        hash_amount.times do |i|
+          t_res = @channel.receive
+          res[t_res[0]] = t_res[1]
+
+          unless progressbar.nil?
+            progressbar.fraction = Math.min(progressbar.fraction + step, 1.0)
+            progressbar.text = sprintf(Gettext.gettext("%d of %d hashes calculated"), {i + 1, hash_amount})
+          end
+        end
+
+        on_finished(res, &block)
+      end
     end
   end
 end

--- a/src/collision/widgets/hash_row.cr
+++ b/src/collision/widgets/hash_row.cr
@@ -1,0 +1,52 @@
+module Collision::Widgets
+  @[Gtk::UiTemplate(
+    resource: "/dev/geopjr/Collision/ui/hash_row.ui",
+    children: {
+      "copy_btn",
+    }
+  )]
+  class HashRow < Adw::ActionRow
+    include Gtk::WidgetTemplate
+    signal clicked(hash_type : String)
+    property copy_btn_locked : Bool = false
+    @copy_btn : Gtk::Button
+    @hash_type : String = ""
+
+    def initialize
+      super()
+
+      @copy_btn = Gtk::Button.cast(template_child("copy_btn"))
+      @copy_btn.clicked_signal.connect(->copy_btn_clicked_cb)
+    end
+
+    def initialize(hash_name : String, @hash_type : String)
+      initialize
+
+      self.title = hash_name
+    end
+
+    def copy_btn_clicked_cb
+      return if @copy_btn_locked
+      @copy_btn_locked = true
+      Collision::LOGGER.debug { "Copied #{title} hash" }
+
+      clicked_signal.emit(@hash_type)
+      success = true
+
+      @copy_btn.icon_name = Collision::Feedback.icon(success)
+      feedback_class = success ? "success" : "error"
+      @copy_btn.add_css_class(feedback_class)
+      Non::Blocking.spawn do
+        sleep 1.1.seconds # 1 feels fast, 1.5 feels slow
+        GLib.idle_add do
+          @copy_btn.icon_name = "edit-copy-symbolic"
+          @copy_btn.remove_css_class(feedback_class)
+          @copy_btn_locked = false
+          false
+        end
+
+        Collision::LOGGER.debug { "Copy button feedback reset" }
+      end
+    end
+  end
+end

--- a/src/collision/window.cr
+++ b/src/collision/window.cr
@@ -21,6 +21,7 @@ module Collision
       "compareBtnStack",
       "switcher_bar",
       "hash_row_container",
+      "progressbar",
     }
   )]
   class Window < Adw::ApplicationWindow
@@ -39,6 +40,7 @@ module Collision
     @mainStack : Gtk::Stack
     @fileInfo : Adw::StatusPage
     @switcher_bar : Adw::ViewSwitcherBar
+    @progressbar : Gtk::ProgressBar
 
     @verifyOverlayLabel : Gtk::Label
     @verifyTextView : Gtk::TextView
@@ -53,7 +55,7 @@ module Collision
       @fileInfo.description = Collision::FileUtils.real_path(filepath)
 
       Collision::LOGGER.debug { "Begin generating hashes" }
-      Collision::Checksum.generate(filepath.to_s) do |res|
+      Collision::Checksum.generate(filepath.to_s, @progressbar) do |res|
         sleep 500.milliseconds
         GLib.idle_add do
           res.each do |hash_type, hash_value|
@@ -89,6 +91,7 @@ module Collision
     end
 
     def loading
+      @progressbar.fraction = 0.0
       @mainStack.visible_child_name = "spinner"
       @headerbarStack.visible_child_name = "empty"
       @openFileBtn.visible = false
@@ -208,6 +211,7 @@ module Collision
       @compareBtnImage = Gtk::Image.cast(template_child("compareBtnImage"))
       @compareBtnLabel = Gtk::Label.cast(template_child("compareBtnLabel"))
       @compareBtnStack = Gtk::Stack.cast(template_child("compareBtnStack"))
+      @progressbar = Gtk::ProgressBar.cast(template_child("progressbar"))
 
       @mainFileChooserNative = Gtk::FileChooserNative.cast(template_child("mainFileChooserNative"))
       @compareBtnFileChooserNative = Gtk::FileChooserNative.cast(template_child("compareBtnFileChooserNative"))

--- a/src/collision/window.cr
+++ b/src/collision/window.cr
@@ -55,12 +55,12 @@ module Collision
       @fileInfo.description = Collision::FileUtils.real_path(filepath)
 
       Collision::LOGGER.debug { "Begin generating hashes" }
-      Collision::Checksum.generate(filepath.to_s, @progressbar) do |res|
+      Collision::Checksum.new.generate(filepath.to_s, @progressbar) do |res|
         sleep 500.milliseconds
         GLib.idle_add do
           res.each do |hash_type, hash_value|
             @hash_results[hash_type] = hash_value
-            @hash_rows[hash_type].subtitle = hash_value.size < 8 ? hash_value : Collision::Checksum.split_by_4(hash_value)
+            @hash_rows[hash_type].subtitle = hash_value.size < 8 ? hash_value : Collision.split_by_4(hash_value)
           end
 
           @mainStack.visible_child_name = "results"
@@ -147,8 +147,8 @@ module Collision
       @compareBtn.remove_css_class("error")
 
       @compareBtnLabel.label = file_path.basename.to_s
-      Collision::Checksum.spawn do
-        compareFileSHA256 = Collision::Checksum.calculate(:sha256, file.path.to_s)
+      Collision.spawn do
+        compareFileSHA256 = Collision::Checksum.new.calculate(:sha256, file.path.to_s)
         result = @hash_results[:sha256] == compareFileSHA256
         result = Collision::FileUtils.compare_content(file_path, @hash_results.values) if !result && File.size(file_path) < MAX_COMPARE_READ_SIZE
         classes = Collision::Feedback.class(result)

--- a/src/collision/window.cr
+++ b/src/collision/window.cr
@@ -227,8 +227,15 @@ module Collision
       @mainFileChooserNative.response_signal.connect do |response|
         next unless response == -3
 
-        self.file = @mainFileChooserNative.file.not_nil!
+        gio_files = [] of Gio::File
+        files = @mainFileChooserNative.files
+        files.n_items.times do |i|
+          gio_files << Gio::File.cast(files.item(i).not_nil!)
+        end
+
         loading
+        self.file = gio_files.shift
+        open_files(Adw::Application.cast(self.application.not_nil!), gio_files) unless gio_files.empty? || self.application.nil?
       rescue ex
         Collision::LOGGER.debug { ex }
       end

--- a/src/collision/window.cr
+++ b/src/collision/window.cr
@@ -1,291 +1,251 @@
 require "./functions/*"
+require "./widgets/*"
 
-@[Gtk::UiTemplate(
-  resource: "/dev/geopjr/Collision/ui/application.ui",
-  children: {
-    "welcomeBtn",
-    "mainFileChooserNative",
-    "compareBtnFileChooserNative",
-    "mainStack",
-    "fileInfo",
-    "headerbarStack",
-    "openFileBtn",
-    "compareBtn",
-    "verifyOverlayLabel",
-    "verifyTextView",
-    "verifyFeedback",
-    "compareBtnImage",
-    "compareBtnLabel",
-    "compareBtnStack",
-    "switcher_bar",
+module Collision
+  @[Gtk::UiTemplate(
+    resource: "/dev/geopjr/Collision/ui/application.ui",
+    children: {
+      "welcomeBtn",
+      "mainFileChooserNative",
+      "compareBtnFileChooserNative",
+      "mainStack",
+      "fileInfo",
+      "headerbarStack",
+      "openFileBtn",
+      "compareBtn",
+      "verifyOverlayLabel",
+      "verifyTextView",
+      "verifyFeedback",
+      "compareBtnImage",
+      "compareBtnLabel",
+      "compareBtnStack",
+      "switcher_bar",
+      "hash_row_container",
+    }
+  )]
+  class Window < Adw::ApplicationWindow
+    include Gtk::WidgetTemplate
 
-    "MD5_row",
-    "MD5_btn",
-    "SHA1_row",
-    "SHA1_btn",
-    "SHA256_row",
-    "SHA256_btn",
-    "SHA512_row",
-    "SHA512_btn",
-  }
-)]
-class CollisionWindow < Adw::ApplicationWindow
-  include Gtk::WidgetTemplate
+    @hash_rows = Hash(Symbol, Widgets::HashRow).new
+    @headerbarStack : Gtk::Stack
+    @welcomeBtn : Gtk::Button
+    @compareBtn : Gtk::Button
+    @compareBtnImage : Gtk::Image
+    @compareBtnLabel : Gtk::Label
+    @compareBtnStack : Gtk::Stack
+    @openFileBtn : Gtk::Button
+    @mainFileChooserNative : Gtk::FileChooserNative
+    @compareBtnFileChooserNative : Gtk::FileChooserNative
+    @mainStack : Gtk::Stack
+    @fileInfo : Adw::StatusPage
+    @switcher_bar : Adw::ViewSwitcherBar
 
-  @MD5_row : Adw::ActionRow
-  @SHA1_row : Adw::ActionRow
-  @SHA256_row : Adw::ActionRow
-  @SHA512_row : Adw::ActionRow
+    @verifyOverlayLabel : Gtk::Label
+    @verifyTextView : Gtk::TextView
+    @verifyFeedback : Gtk::Image
 
-  @MD5_btn : Gtk::Button
-  @SHA1_btn : Gtk::Button
-  @SHA256_btn : Gtk::Button
-  @SHA512_btn : Gtk::Button
+    @hash_results = Hash(Symbol, String).new
 
-  @headerbarStack : Gtk::Stack
-  @welcomeBtn : Gtk::Button
-  @compareBtn : Gtk::Button
-  @compareBtnImage : Gtk::Image
-  @compareBtnLabel : Gtk::Label
-  @compareBtnStack : Gtk::Stack
-  @openFileBtn : Gtk::Button
-  @mainFileChooserNative : Gtk::FileChooserNative
-  @compareBtnFileChooserNative : Gtk::FileChooserNative
-  @mainStack : Gtk::Stack
-  @fileInfo : Adw::StatusPage
-  @switcher_bar : Adw::ViewSwitcherBar
+    def file=(filepath : Path)
+      Collision::LOGGER.debug { "File set: \"#{filepath}\"" }
 
-  @verifyOverlayLabel : Gtk::Label
-  @verifyTextView : Gtk::TextView
-  @verifyFeedback : Gtk::Image
+      @fileInfo.title = filepath.basename.to_s
+      @fileInfo.description = Collision::FileUtils.real_path(filepath)
 
-  @hash_results = Hash(String, String).new
-
-  def file=(filepath : Path)
-    Collision::LOGGER.debug { "File set: \"#{filepath}\"" }
-
-    @fileInfo.title = filepath.basename.to_s
-    @fileInfo.description = Collision::FileUtils.real_path(filepath)
-
-    Collision::LOGGER.debug { "Begin generating hashes" }
-    Collision::Checksum.generate(filepath.to_s) do |res|
-      sleep 500.milliseconds
-      GLib.idle_add do
-        res.each do |hash_type, hash_value|
-          @hash_results[hash_type] = hash_value
-          {% begin %}
-            case hash_type
-            {% for hash_function in Collision::HASH_FUNCTIONS %}
-              when {{hash_function}}
-                @{{hash_function.id}}_row.subtitle = Collision::Checksum.split_by_4(hash_value)
-            {% end %}
-            end
-          {% end %}
-        end
-
-        @mainStack.visible_child_name = "results"
-        @headerbarStack.visible_child_name = "switcher"
-        @openFileBtn.visible = true
-        @switcher_bar.visible = true
-
-        false
-      end
-    end
-  end
-
-  # For Gio::File.
-  # Should be used instead of Collision#file=(filepath : Path)
-  # unless path is a File and exists.
-  def file=(file : Gio::File)
-    Collision::FileUtils.file?(file.path.not_nil!)
-    self.file = file.path.not_nil!
-  end
-
-  def on_open_btn_clicked
-    @mainFileChooserNative.show
-  end
-
-  def on_drop(file : Gio::File)
-    loading
-    self.file = file
-  end
-
-  def loading
-    @mainStack.visible_child_name = "spinner"
-    @headerbarStack.visible_child_name = "empty"
-    @openFileBtn.visible = false
-    @switcher_bar.visible = false
-    reset_feedback
-  end
-
-  def reset_feedback
-    @verifyTextView.buffer.text = ""
-    @compareBtnStack.visible_child_name = "image"
-    @compareBtnLabel.label = Gettext.gettext("Choose File…")
-    @compareBtn.remove_css_class("success")
-    @compareBtn.remove_css_class("error")
-    @compareBtnImage.icon_name = "paper-symbolic"
-  end
-
-  def handle_input_change(text : String)
-    result = @hash_results.values.includes?(text.downcase.gsub(' ', ""))
-    if text.size == 0
-      @verifyOverlayLabel.visible = true
-      @verifyFeedback.visible = false
-      @verifyTextView.remove_css_class("success")
-      @verifyTextView.remove_css_class("error")
-      return
-    end
-
-    @verifyOverlayLabel.visible = false
-    @verifyFeedback.visible = true
-
-    classes = Collision::Feedback.class(result)
-
-    @verifyTextView.add_css_class(classes[:add])
-    @verifyTextView.remove_css_class(classes[:remove])
-
-    @verifyFeedback.icon_name = Collision::Feedback.icon(result)
-    @verifyFeedback.add_css_class(classes[:add])
-    @verifyFeedback.remove_css_class(classes[:remove])
-  end
-
-  # We want to only check the file contents
-  # IF the file is smaller than the size below.
-  # We want to avoid loading a huge file in
-  # memory but also avoid false-positives.
-  MAX_COMPARE_READ_SIZE = 10000 # in bytes
-
-  def comparefile=(file : Gio::File)
-    Collision::LOGGER.debug { "Begin comparing tool" }
-    file_path = file.path.not_nil!
-    Collision::FileUtils.file?(file_path)
-
-    @compareBtnStack.visible_child_name = "spinner"
-    @compareBtn.remove_css_class("success")
-    @compareBtn.remove_css_class("error")
-
-    @compareBtnLabel.label = file_path.basename.to_s
-    Collision::Checksum.spawn do
-      compareFileSHA256 = Collision::Checksum.calculate("sha256", file.path.to_s)
-      result = @hash_results["SHA256"] == compareFileSHA256
-      result = Collision::FileUtils.compare_content(file_path, @hash_results.values) if !result && File.size(file_path) < MAX_COMPARE_READ_SIZE
-      classes = Collision::Feedback.class(result)
-
-      sleep 500.milliseconds
-
-      GLib.idle_add do
-        @compareBtnStack.visible_child_name = "image"
-
-        @compareBtnImage.icon_name = Collision::Feedback.icon(result)
-        @compareBtn.add_css_class(classes[:add])
-        @compareBtn.remove_css_class(classes[:remove])
-
-        false
-      end
-
-      Collision::LOGGER.debug { "Finished comparing tool" }
-    end
-  end
-
-  def initialize
-    super()
-
-    @MD5_row = Adw::ActionRow.cast(template_child("MD5_row"))
-    @SHA1_row = Adw::ActionRow.cast(template_child("SHA1_row"))
-    @SHA256_row = Adw::ActionRow.cast(template_child("SHA256_row"))
-    @SHA512_row = Adw::ActionRow.cast(template_child("SHA512_row"))
-
-    @MD5_btn = Gtk::Button.cast(template_child("MD5_btn"))
-    @SHA1_btn = Gtk::Button.cast(template_child("SHA1_btn"))
-    @SHA256_btn = Gtk::Button.cast(template_child("SHA256_btn"))
-    @SHA512_btn = Gtk::Button.cast(template_child("SHA512_btn"))
-
-    @verifyOverlayLabel = Gtk::Label.cast(template_child("verifyOverlayLabel"))
-    @verifyTextView = Gtk::TextView.cast(template_child("verifyTextView"))
-    @verifyFeedback = Gtk::Image.cast(template_child("verifyFeedback"))
-
-    @mainStack = Gtk::Stack.cast(template_child("mainStack"))
-    @headerbarStack = Gtk::Stack.cast(template_child("headerbarStack"))
-    @switcher_bar = Adw::ViewSwitcherBar.cast(template_child("switcher_bar"))
-
-    @welcomeBtn = Gtk::Button.cast(template_child("welcomeBtn"))
-    @fileInfo = Adw::StatusPage.cast(template_child("fileInfo"))
-    @openFileBtn = Gtk::Button.cast(template_child("openFileBtn"))
-
-    @compareBtn = Gtk::Button.cast(template_child("compareBtn"))
-    @compareBtnImage = Gtk::Image.cast(template_child("compareBtnImage"))
-    @compareBtnLabel = Gtk::Label.cast(template_child("compareBtnLabel"))
-    @compareBtnStack = Gtk::Stack.cast(template_child("compareBtnStack"))
-
-    @mainFileChooserNative = Gtk::FileChooserNative.cast(template_child("mainFileChooserNative"))
-    @compareBtnFileChooserNative = Gtk::FileChooserNative.cast(template_child("compareBtnFileChooserNative"))
-    @mainFileChooserNative.transient_for = self
-    @compareBtnFileChooserNative.transient_for = self
-
-    @verifyTextView.buffer.notify_signal["text"].connect do
-      Collision::LOGGER.debug { "Verify tool notify event" }
-
-      handle_input_change(@verifyTextView.buffer.text)
-    end
-
-    @mainFileChooserNative.response_signal.connect do |response|
-      next unless response == -3
-
-      self.file = @mainFileChooserNative.file.not_nil!
-      loading
-    rescue ex
-      Collision::LOGGER.debug { ex }
-    end
-
-    @compareBtnFileChooserNative.response_signal.connect do |response|
-      next unless response == -3
-
-      self.comparefile = @compareBtnFileChooserNative.file.not_nil!
-    rescue ex
-      Collision::LOGGER.debug { ex }
-    end
-
-    @welcomeBtn.clicked_signal.connect(->on_open_btn_clicked)
-    @openFileBtn.clicked_signal.connect(->on_open_btn_clicked)
-
-    @mainStack.add_controller(Collision::DragNDrop.new(->on_drop(Gio::File)).controller)
-    @compareBtn.add_controller(Collision::DragNDrop.new(->comparefile=(Gio::File)).controller)
-
-    @compareBtn.clicked_signal.connect do
-      @compareBtnFileChooserNative.show
-    end
-
-    {% for hash in Collision::HASH_FUNCTIONS %}
-      {{hash.downcase.id}}_soft_locked = false
-      @{{hash.id}}_btn.clicked_signal.connect do
-        next if {{hash.downcase.id}}_soft_locked
-        {{hash.downcase.id}}_soft_locked = true
-
-        Collision::LOGGER.debug { {{"Copied #{hash.id} hash"}} }
-
-        success = true
-        begin
-          self.clipboard.set(@hash_results[{{hash}}])
-        rescue
-          success = false
-        end
-
-        @{{hash.id}}_btn.icon_name = Collision::Feedback.icon(success)
-        feedback_class = success ? "success" : "error"
-        @{{hash.id}}_btn.add_css_class(feedback_class)
-        Non::Blocking.spawn do
-          sleep 1.1.seconds # 1 feels fast, 1.5 feels slow
-          GLib.idle_add do
-            @{{hash.id}}_btn.icon_name = "edit-copy-symbolic"
-            @{{hash.id}}_btn.remove_css_class(feedback_class)
-            {{hash.downcase.id}}_soft_locked = false
-            false
+      Collision::LOGGER.debug { "Begin generating hashes" }
+      Collision::Checksum.generate(filepath.to_s) do |res|
+        sleep 500.milliseconds
+        GLib.idle_add do
+          res.each do |hash_type, hash_value|
+            @hash_results[hash_type] = hash_value
+            @hash_rows[hash_type].subtitle = hash_value.size < 8 ? hash_value : Collision::Checksum.split_by_4(hash_value)
           end
 
-          Collision::LOGGER.debug { "Copy button feedback reset" }
+          @mainStack.visible_child_name = "results"
+          @headerbarStack.visible_child_name = "switcher"
+          @openFileBtn.visible = true
+          @switcher_bar.visible = true
+
+          false
         end
       end
-    {% end %}
+    end
+
+    # For Gio::File.
+    # Should be used instead of Collision#file=(filepath : Path)
+    # unless path is a File and exists.
+    def file=(file : Gio::File)
+      Collision::FileUtils.file?(file.path.not_nil!)
+      self.file = file.path.not_nil!
+    end
+
+    def on_open_btn_clicked
+      @mainFileChooserNative.show
+    end
+
+    def on_drop(file : Gio::File)
+      loading
+      self.file = file
+    end
+
+    def loading
+      @mainStack.visible_child_name = "spinner"
+      @headerbarStack.visible_child_name = "empty"
+      @openFileBtn.visible = false
+      @switcher_bar.visible = false
+      reset_feedback
+    end
+
+    def reset_feedback
+      @verifyTextView.buffer.text = ""
+      @compareBtnStack.visible_child_name = "image"
+      @compareBtnLabel.label = Gettext.gettext("Choose File…")
+      @compareBtn.remove_css_class("success")
+      @compareBtn.remove_css_class("error")
+      @compareBtnImage.icon_name = "paper-symbolic"
+    end
+
+    def handle_input_change(text : String)
+      result = @hash_results.values.includes?(text.downcase.gsub(' ', ""))
+      if text.size == 0
+        @verifyOverlayLabel.visible = true
+        @verifyFeedback.visible = false
+        @verifyTextView.remove_css_class("success")
+        @verifyTextView.remove_css_class("error")
+        return
+      end
+
+      @verifyOverlayLabel.visible = false
+      @verifyFeedback.visible = true
+
+      classes = Collision::Feedback.class(result)
+
+      @verifyTextView.add_css_class(classes[:add])
+      @verifyTextView.remove_css_class(classes[:remove])
+
+      @verifyFeedback.icon_name = Collision::Feedback.icon(result)
+      @verifyFeedback.add_css_class(classes[:add])
+      @verifyFeedback.remove_css_class(classes[:remove])
+    end
+
+    # We want to only check the file contents
+    # IF the file is smaller than the size below.
+    # We want to avoid loading a huge file in
+    # memory but also avoid false-positives.
+    MAX_COMPARE_READ_SIZE = 10000 # in bytes
+
+    def comparefile=(file : Gio::File)
+      Collision::LOGGER.debug { "Begin comparing tool" }
+      file_path = file.path.not_nil!
+      Collision::FileUtils.file?(file_path)
+
+      @compareBtnStack.visible_child_name = "spinner"
+      @compareBtn.remove_css_class("success")
+      @compareBtn.remove_css_class("error")
+
+      @compareBtnLabel.label = file_path.basename.to_s
+      Collision::Checksum.spawn do
+        compareFileSHA256 = Collision::Checksum.calculate(:sha256, file.path.to_s)
+        result = @hash_results[:sha256] == compareFileSHA256
+        result = Collision::FileUtils.compare_content(file_path, @hash_results.values) if !result && File.size(file_path) < MAX_COMPARE_READ_SIZE
+        classes = Collision::Feedback.class(result)
+
+        sleep 500.milliseconds
+
+        GLib.idle_add do
+          @compareBtnStack.visible_child_name = "image"
+
+          @compareBtnImage.icon_name = Collision::Feedback.icon(result)
+          @compareBtn.add_css_class(classes[:add])
+          @compareBtn.remove_css_class(classes[:remove])
+
+          false
+        end
+
+        Collision::LOGGER.debug { "Finished comparing tool" }
+      end
+    end
+
+    def copy_btn_cb(hash_type : String)
+      {% begin %}
+        case hash_type
+          {% for hash in Collision::HASH_FUNCTIONS.keys %}
+            when {{hash.stringify}}
+              self.clipboard.set(@hash_results[:{{hash}}])
+          {% end %}
+        end
+      {% end %}
+    end
+
+    macro setup_hashrows
+      {% for hash, digest in Collision::HASH_FUNCTIONS %}
+        hashrow = Collision::Widgets::HashRow.new({{digest}}, {{hash.stringify}})
+        @hash_row_container.append (hashrow)
+        hashrow.clicked_signal.connect(->copy_btn_cb(String))
+        @hash_rows[:{{hash}}] = hashrow
+      {% end %}
+    end
+
+    def initialize
+      super()
+
+      @hash_row_container = Gtk::ListBox.cast(template_child("hash_row_container"))
+      setup_hashrows
+
+      @verifyOverlayLabel = Gtk::Label.cast(template_child("verifyOverlayLabel"))
+      @verifyTextView = Gtk::TextView.cast(template_child("verifyTextView"))
+      @verifyFeedback = Gtk::Image.cast(template_child("verifyFeedback"))
+
+      @mainStack = Gtk::Stack.cast(template_child("mainStack"))
+      @headerbarStack = Gtk::Stack.cast(template_child("headerbarStack"))
+      @switcher_bar = Adw::ViewSwitcherBar.cast(template_child("switcher_bar"))
+
+      @welcomeBtn = Gtk::Button.cast(template_child("welcomeBtn"))
+      @fileInfo = Adw::StatusPage.cast(template_child("fileInfo"))
+      @openFileBtn = Gtk::Button.cast(template_child("openFileBtn"))
+
+      @compareBtn = Gtk::Button.cast(template_child("compareBtn"))
+      @compareBtnImage = Gtk::Image.cast(template_child("compareBtnImage"))
+      @compareBtnLabel = Gtk::Label.cast(template_child("compareBtnLabel"))
+      @compareBtnStack = Gtk::Stack.cast(template_child("compareBtnStack"))
+
+      @mainFileChooserNative = Gtk::FileChooserNative.cast(template_child("mainFileChooserNative"))
+      @compareBtnFileChooserNative = Gtk::FileChooserNative.cast(template_child("compareBtnFileChooserNative"))
+      @mainFileChooserNative.transient_for = self
+      @compareBtnFileChooserNative.transient_for = self
+
+      @verifyTextView.buffer.notify_signal["text"].connect do
+        Collision::LOGGER.debug { "Verify tool notify event" }
+
+        handle_input_change(@verifyTextView.buffer.text)
+      end
+
+      @mainFileChooserNative.response_signal.connect do |response|
+        next unless response == -3
+
+        self.file = @mainFileChooserNative.file.not_nil!
+        loading
+      rescue ex
+        Collision::LOGGER.debug { ex }
+      end
+
+      @compareBtnFileChooserNative.response_signal.connect do |response|
+        next unless response == -3
+
+        self.comparefile = @compareBtnFileChooserNative.file.not_nil!
+      rescue ex
+        Collision::LOGGER.debug { ex }
+      end
+
+      @welcomeBtn.clicked_signal.connect(->on_open_btn_clicked)
+      @openFileBtn.clicked_signal.connect(->on_open_btn_clicked)
+
+      @mainStack.add_controller(Collision::DragNDrop.new(->on_drop(Gio::File)).controller)
+      @compareBtn.add_controller(Collision::DragNDrop.new(->comparefile=(Gio::File)).controller)
+
+      @compareBtn.clicked_signal.connect do
+        @compareBtnFileChooserNative.show
+      end
+    end
   end
 end


### PR DESCRIPTION
fix: #102 
fix: #176 

- Adds Blake3 (shard), CRC32 (std), Adler32 (std)
- Dynamically creates the rows
- Use symbols for the hash types
- Use named tuple for the functions (type: digest)
- Move away from openssl and instead use digest directly
- Create new digest instances for every calculation (fixes crash due to finalizing > 1)
- Support for opening multiple files from the file picker (opens new windows)
- Shows loading screen when opening with file

TODO:
- #166
- ~~Update flatpak config~~