### PR TITLE
chore: bump blake3.cr

### DIFF
--- a/data/dev.geopjr.Collision.json
+++ b/data/dev.geopjr.Collision.json
@@ -83,8 +83,8 @@
         {
           "type": "archive",
           "dest": "crystal/",
-          "url": "https://github.com/crystal-lang/crystal/releases/download/1.10.1/crystal-1.10.1-1-linux-x86_64.tar.gz",
-          "sha256": "1742e3755d3653d1ba07c0291f10a517fa392af87130dba4497ed9d82c12348b",
+          "url": "https://github.com/crystal-lang/crystal/releases/download/1.11.2/crystal-1.11.2-1-linux-x86_64.tar.gz",
+          "sha256": "732eea9df6458c89157dae945fb0adbee0beb6345ca03bc3ccd299b2bf0879ae",
           "only_arches": [
             "x86_64"
           ]
@@ -101,7 +101,7 @@
         {
           "type": "git",
           "url": "https://github.com/geopjr/blake3.cr.git",
-          "tag": "v1.2.0",
+          "tag": "v1.3.0",
           "dest": "lib/blake3"
         },
         {

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   blake3:
     git: https://github.com/geopjr/blake3.cr.git
-    version: 1.2.0
+    version: 1.3.0
 
   gettext:
     git: https://github.com/geopjr/gettext.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -20,7 +20,7 @@ dependencies:
     version: ~> 1.0.0
   blake3:
     github: GeopJr/blake3.cr
-    version: ~> 1.2.0
+    version: ~> 1.3.0
 
 crystal: 1.9.2
 

--- a/spec/hash_generator_spec.cr
+++ b/spec/hash_generator_spec.cr
@@ -15,7 +15,7 @@ describe Collision::Checksum do
 
     safe_stop = Time.utc.to_unix_ms
     loop do
-      break if Collision::CLIPBOARD_HASH.size == hashes.size || Time.utc.to_unix_ms - safe_stop > Collision::CLIPBOARD_HASH.size * 1000
+      break if Collision::CLIPBOARD_HASH.size == hashes.size || Time.utc.to_unix_ms - safe_stop > Collision::CLIPBOARD_HASH.size * 5000
     end
 
     Collision::CLIPBOARD_HASH.each do |k, v|


### PR DESCRIPTION
The previous version of blak3cr would depend on a postinstall script + makefile to build blake3c. It now uses a macro to detect the correct arch and run the correct commands to properly build it.