### PR TITLE
Update Developer ID

### DIFF
--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -5,7 +5,7 @@
   <project_license>BSD-2-Clause</project_license>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Evangelos "GeopJr" Paterakis</developer_name>
-  <developer id="geopjr.dev">
+  <developer id="dev.geopjr">
       <name translatable="no">Evangelos "GeopJr" Paterakis</name>
   </developer>
   <summary>Check hashes for your files</summary>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDs.

More information: https://github.com/ximion/appstream/issues/575

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer