### PR TITLE
feat(metainfo): new screenshots

### DIFF
--- a/data/screenshots/screenshot-1.png
+++ b/data/screenshots/screenshot-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7aa8a7020d54aaf11f846adb6a7929953b724a3a06957afd7952646564bb0f20
-size 21622
+oid sha256:b28b5b87d2c1098a7cce3f1a9c71732601e6913e0617db718975a48fd5da0bbb
+size 46617

--- a/data/screenshots/screenshot-2.png
+++ b/data/screenshots/screenshot-2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c6fbf40036601b41fafe12b69773a5f6674687b9cb109feef43a2d21bb7eb0b
-size 47947
+oid sha256:6bef3291f08a69127c248e909ca3b395381e8988c4f41bcb289c1efef1a4df25
+size 29443

--- a/data/screenshots/screenshot-3.png
+++ b/data/screenshots/screenshot-3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3937ff9335e4cc2891261f865953a3a7a227875810066e727c5cc135eb4b780
-size 29588
+oid sha256:f225e0a6462d9c3e151ced3d6cf127b5946aef1abb86c0ca753b0cb5dce4adda
+size 33601

--- a/data/screenshots/screenshot-4.png
+++ b/data/screenshots/screenshot-4.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:077eb97381b97ff2cf2d12a7c2370da54f6681f6c3f931fb852f9cc56a47d946
-size 36362
+oid sha256:7aa8a7020d54aaf11f846adb6a7929953b724a3a06957afd7952646564bb0f20
+size 21622


### PR DESCRIPTION
fix: #199 

- empty state screenshot was moved to end
- changed the open file to gnome-shell: smaller title than crystal releases, gnome related