### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -4,9 +4,9 @@
   <name>Collision</name>
   <project_license>BSD-2-Clause</project_license>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Evangelos "GeopJr" Paterakis</developer_name>
+  <developer_name translate="no">Evangelos "GeopJr" Paterakis</developer_name>
   <developer id="dev.geopjr">
-      <name translatable="no">Evangelos "GeopJr" Paterakis</name>
+      <name translate="no">Evangelos "GeopJr" Paterakis</name>
   </developer>
   <summary>Check hashes for your files</summary>
   <metadata_license>CC0-1.0</metadata_license>
@@ -49,7 +49,7 @@
   </branding>
   <releases>
     <release version="3.8.0" date="2024-03-26">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Visual refinements to match the state of the art of GNOME apps</li>
           <li>Improved accessibility</li>
@@ -59,14 +59,14 @@
       </description>
     </release>
     <release version="3.7.1" date="2024-01-24">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated translations</li>
         </ul>
       </description>
     </release>
     <release version="3.7.0" date="2024-01-02">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Blake3, CRC32 and Adler32 support</li>
           <li>Added progress bar for tracking the calculation progress</li>
@@ -79,7 +79,7 @@
       </description>
     </release>
     <release version="3.6.0" date="2023-09-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Visual refinements to match the state of the art of GNOME apps</li>
           <li>Major codebase rewrite</li>
@@ -89,7 +89,7 @@
       </description>
     </release>
     <release version="3.5.0" date="2023-04-17">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added drag and drop support for files</li>
           <li>Improved keyboard navigation</li>
@@ -99,7 +99,7 @@
       </description>
     </release>
     <release version="3.4.0" date="2023-01-06">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added keyboard shortcuts</li>
           <li>Added ability to search for hashes in file content</li>
@@ -110,7 +110,7 @@
       </description>
     </release>
     <release version="3.3.1" date="2022-11-24">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added aarch64 support</li>
           <li>Added nautilus / GNOME Files extension by DodoLeDev</li>
@@ -120,7 +120,7 @@
       </description>
     </release>
     <release version="3.3.0" date="2022-11-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added open signal handling (you can now open files with Collision)</li>
           <li>Minor bug fixes</li>
@@ -131,7 +131,7 @@
       </description>
     </release>
     <release version="3.2.0" date="2022-10-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Switched to AdwAboutWindow</li>
           <li>Minor bug fixes</li>
@@ -141,7 +141,7 @@
       </description>
     </release>
     <release version="3.1.0" date="2022-09-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added gschema support so Collision remembers window size and maximized state</li>
           <li>Updated dependencies</li>
@@ -151,7 +151,7 @@
       </description>
     </release>
     <release version="3.0.5" date="2022-08-11">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Optimized performance and memory usage of CSS class toggling</li>
           <li>Minor bug fixes</li>
@@ -162,7 +162,7 @@
       </description>
     </release>
     <release version="3.0.4" date="2022-07-04">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated dependencies</li>
           <li>Added Estonian, Czech and Berber translations</li>
@@ -171,7 +171,7 @@
       </description>
     </release>
     <release version="3.0.3" date="2022-05-21">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Handle feedback on buttons when spammed</li>
           <li>Hash comparison is now case-insensitive</li>
@@ -182,7 +182,7 @@
       </description>
     </release>
     <release version="3.0.2" date="2022-04-22">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Feedback on copy</li>
           <li>Updated translations</li>
@@ -190,7 +190,7 @@
       </description>
     </release>
     <release version="3.0.1" date="2022-03-27">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Bug fixes</li>
           <li>Hide filepath on flatpak</li>

--- a/data/dev.geopjr.Collision.metainfo.xml.in
+++ b/data/dev.geopjr.Collision.metainfo.xml.in
@@ -15,7 +15,7 @@
   <url type="translate">https://hosted.weblate.org/engage/collision/</url>
   <url type="donation">https://geopjr.dev/donate</url>
   <url type="vcs-browser">https://github.com/GeopJr/Collision/</url>
-  <url type="contribute">https://welcome.gnome.org/en/app/Collision/</url>
+  <url type="contribute">https://welcome.gnome.org/app/Collision/</url>
   <description>
     <p>
       Verifying that a file you downloaded or received is actually the one you were


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract the
`translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process
before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Fix contribute URL

welcome.gnome.org is translatable and don't redirect user to English page.
