### PR TITLE
fix(nautilus extension): 4.1 support and use once instance for all files

### DIFF
--- a/nautilus-extension/collision-extension.py
+++ b/nautilus-extension/collision-extension.py
@@ -39,18 +39,20 @@ class NautilusCollision(Nautilus.MenuProvider, GObject.GObject):
     
     # Executed method when the right-click entry is clicked
     def openWithCollision(self, menu, files):
+        args = [self.collision]
         for file in files:
             file_path = repr(unquote(urlparse(file.get_uri()).path))
             if self.collision != "collision":
                 file_path = "@@ " + file_path + " @@"
-            Popen(self.collision + " " + file_path, shell=True)  # Collision need to be in your PATH
+            args.append(file_path)
+        Popen(" ".join(args), shell=True)  # Collision need to be in your PATH
     
     def get_background_items(self, files):
         return
 
     def get_file_items(self, files):
         # The option doesn't appear when a folder is selected
-        if any(x.is_directory() for x in files) or self.collision == False: 
+        if self.collision == False or any(x.is_directory() for x in files): 
             return ()
 
         menu_item = Nautilus.MenuItem(


### PR DESCRIPTION
fix: #230 

Apart for the 4.1 fix, it now opens all files in a single collision instance. In the past to avoid segfaults due to GC <=> ref counting, we'd use a different instance for each file, in the current versions of collision, everything runs in parallel contexts that better isolate memory access and this is no longer an issue.